### PR TITLE
Save some RAM by putting strings only to program memory.

### DIFF
--- a/src/internals/StreamHttpReply.cpp
+++ b/src/internals/StreamHttpReply.cpp
@@ -27,16 +27,17 @@ void ArduinoHttpServer::AbstractStreamHttpReply::send(const String& data, const 
    // Read away remaining bytes.
    while(getStream().read()>=0);
 
-   String httpErrorReply("HTTP/1.1 ");
+   String httpErrorReply;
+   httpErrorReply += F("HTTP/1.1 ");
    httpErrorReply += getCode() + " ";
-   httpErrorReply +=  title + "\r\n";
-   httpErrorReply += "Connection: close\r\n";
-   httpErrorReply += "Content-Length: ";
-   httpErrorReply += data.length(); httpErrorReply += "\r\n";
-   httpErrorReply += "Content-Type: "; httpErrorReply += m_contentType; httpErrorReply+= "\r\n";
-   httpErrorReply += "\r\n";
+   httpErrorReply += title + "\r\n";
+   httpErrorReply += F("Connection: close\r\n");
+   httpErrorReply += F("Content-Length: ");
+   httpErrorReply += data.length(); httpErrorReply += F("\r\n");
+   httpErrorReply += F("Content-Type: "); httpErrorReply += m_contentType; httpErrorReply+= F("\r\n");
+   httpErrorReply += F("\r\n");
    httpErrorReply += data;
-   httpErrorReply += "\r\n";
+   httpErrorReply += F("\r\n");
 
    DEBUG_ARDUINO_HTTP_SERVER_PRINT("Printing Reply ... ");
    getStream().print(httpErrorReply);
@@ -108,13 +109,13 @@ void ArduinoHttpServer::StreamHttpErrorReply::send(const String& data)
 String ArduinoHttpServer::StreamHttpErrorReply::getHtmlBody(const String& data)
 {
    String body;
-   body += "<html><head><title>Error: ";
+   body += F("<html><head><title>Error: ");
    body += getCode();
-   body += "</title></head><body><h3>Error ";
+   body += F("</title></head><body><h3>Error ");
    body += getCode();
-   body += ": ";
+   body += F(": ");
    body += data;
-   body += "</h3></body></html>";
+   body += F("</h3></body></html>");
 
    return body;
 }
@@ -126,9 +127,9 @@ String ArduinoHttpServer::StreamHttpErrorReply::getJsonBody(const String& data)
    dataCopy.replace("\"", "\\\"");
 
    String body;
-   body += "{\"Error\": \"";
+   body += F("{\"Error\": \"");
    body +=dataCopy;
-   body += "\"}";
+   body += F("\"}");
 
    return body;
 }

--- a/src/internals/StreamHttpRequest.hpp
+++ b/src/internals/StreamHttpRequest.hpp
@@ -135,7 +135,7 @@ bool ArduinoHttpServer::StreamHttpRequest<MAX_BODY_LENGTH>::readRequest()
       // Quit when failed to retrieve data after n retries.
       if(attempts >= MAX_RETRIES_WAIT_DATA_AVAILABLE)
       {
-         setError("Time out while waiting for data to become available.");
+         setError(F("Time out while waiting for data to become available."));
          break;
       }
 
@@ -240,8 +240,14 @@ void ArduinoHttpServer::StreamHttpRequest<MAX_BODY_LENGTH>::parseMethod(char lin
    }
    else
    {
+      String errorStr;
+      
       m_method = MethodInvalid;
-      setError(String("Cannot handle HTTP method: \"")+token+"\".");
+      
+      errorStr += F("Cannot handle HTTP method: \"");
+      errorStr += token;
+      errorStr += F("\".");
+      setError(errorStr);
    }
 }
 
@@ -261,7 +267,8 @@ void ArduinoHttpServer::StreamHttpRequest<MAX_BODY_LENGTH>::parseVersion()
     }
     else
     {
-        String message("Parse error. Invalid HTTP version: \"");
+        String message;
+        message += F("Parse error. Invalid HTTP version: \"");
         message += version;
         message += "\".";
         setError(message);
@@ -280,7 +287,7 @@ void ArduinoHttpServer::StreamHttpRequest<MAX_BODY_LENGTH>::parseResource()
 
     if (!m_resource.isValid())
     {
-        setError("Parse error. No resource specified.");
+        setError(F("Parse error. No resource specified."));
     }
 }
 


### PR DESCRIPTION
Store strings only in the program memory, instead of keeping them additional in the RAM. This helps much using the library on small Arduino devices, especially for the Atmel controllers.