### PR TITLE
Add basic authorization support.

### DIFF
--- a/examples/HelloHttp/HelloHttp.ino
+++ b/examples/HelloHttp/HelloHttp.ino
@@ -72,6 +72,7 @@ void loop()
 
          httpReply.send( errorStr );
       }
+      client.stop();
    }
 
 }

--- a/library.properties
+++ b/library.properties
@@ -8,3 +8,4 @@ category=Communication
 url=https://github.com/QuickSander/ArduinoHttpServer
 architectures=*
 repository=https://github.com/QuickSander/ArduinoHttpServer.git
+depends=Base64

--- a/src/internals/HttpField.cpp
+++ b/src/internals/HttpField.cpp
@@ -14,6 +14,7 @@ const char* ArduinoHttpServer::HttpField::SEPERATOR = ": ";
 const char* ArduinoHttpServer::HttpField::CONTENT_TYPE_STR = "Content-Type";
 const char* ArduinoHttpServer::HttpField::CONTENT_LENGTH_TYPE_STR = "Content-Length";
 const char* ArduinoHttpServer::HttpField::USER_AGENT_TYPE_STR = "User-Agent";
+const char* ArduinoHttpServer::HttpField::AUTHORIZATION_TYPE_STR = "Authorization";
 
 
 ArduinoHttpServer::HttpField::HttpField(const char* fieldLine) :
@@ -65,6 +66,10 @@ void ArduinoHttpServer::HttpField::determineType(const String& typeStr)
    else if (typeStr.equalsIgnoreCase(USER_AGENT_TYPE_STR))
    {
       m_type = Type::USER_AGENT;
+   }
+   else if (typeStr.equalsIgnoreCase(AUTHORIZATION_TYPE_STR))
+   {
+      m_type = Type::AUTHORIZATION;
    }
 }
 

--- a/src/internals/HttpField.hpp
+++ b/src/internals/HttpField.hpp
@@ -26,7 +26,8 @@ public:
       NOT_SUPPORTED,
       CONTENT_TYPE,
       CONTENT_LENGTH,
-      USER_AGENT
+      USER_AGENT,
+      AUTHORIZATION
    };
 
    HttpField(const char* fieldLine);
@@ -49,6 +50,7 @@ private:
    static const char* CONTENT_TYPE_STR;
    static const char* CONTENT_LENGTH_TYPE_STR;
    static const char* USER_AGENT_TYPE_STR;
+   static const char* AUTHORIZATION_TYPE_STR;
 
    Type m_type;
    String m_value;

--- a/src/internals/StreamHttpReply.cpp
+++ b/src/internals/StreamHttpReply.cpp
@@ -32,8 +32,11 @@ void ArduinoHttpServer::AbstractStreamHttpReply::send(const String& data, const 
    httpErrorReply += title + "\r\n";
    httpErrorReply += AHS_F("Connection: close\r\n");
    httpErrorReply += AHS_F("Content-Length: ");
-   httpErrorReply += data.length(); httpErrorReply += AHS_F("\r\n");
-   httpErrorReply += AHS_F("Content-Type: "); httpErrorReply += m_contentType; httpErrorReply+= AHS_F("\r\n");
+   httpErrorReply += data.length();
+   httpErrorReply += AHS_F("\r\n");
+   httpErrorReply += AHS_F("Content-Type: ");
+   httpErrorReply += m_contentType;
+   httpErrorReply += AHS_F("\r\n");
    httpErrorReply += AHS_F("\r\n");
    httpErrorReply += data;
    httpErrorReply += AHS_F("\r\n");
@@ -131,4 +134,30 @@ String ArduinoHttpServer::StreamHttpErrorReply::getJsonBody(const String& data)
    body += AHS_F("\"}");
 
    return body;
+}
+
+//------------------------------------------------------------------------------
+//                             Class Definition
+//------------------------------------------------------------------------------
+
+ArduinoHttpServer::StreamHttpAuthenticateReply::StreamHttpAuthenticateReply(Stream& stream, const String& contentType) :
+   AbstractStreamHttpReply(stream, contentType, "401")
+{
+
+}
+
+void ArduinoHttpServer::StreamHttpAuthenticateReply::send()
+{
+   // Read away remaining bytes.
+   while(getStream().read()>=0);
+
+   DEBUG_ARDUINO_HTTP_SERVER_PRINT("Printing Reply ... ");
+   getStream().println(AHS_F("HTTP/1.1 401 Unauthorized"));
+   getStream().println(AHS_F("WWW-Authenticate: Basic realm=\"Login Required\""));
+   getStream().println(AHS_F("Connection: close"));
+   getStream().println(AHS_F(""));
+   getStream().println(AHS_F("<HTML><HEAD><TITLE>401 Unauthorized</TITLE></HEAD><BODY BGCOLOR=\"#cc9999\"><H4>401 Unauthorized</H4>Authorization required.</BODY></HTML>"));
+   getStream().println(AHS_F(""));
+   getStream().println(AHS_F(""));
+   DEBUG_ARDUINO_HTTP_SERVER_PRINTLN("done.");
 }

--- a/src/internals/StreamHttpReply.hpp
+++ b/src/internals/StreamHttpReply.hpp
@@ -62,6 +62,18 @@ protected:
 //------------------------------------------------------------------------------
 //                             Class Declaration
 //------------------------------------------------------------------------------
+//! Authenticate reply
+class StreamHttpAuthenticateReply: public AbstractStreamHttpReply
+{
+public:
+    StreamHttpAuthenticateReply(Stream& stream, const String& contentType);
+    virtual void send();
+};
+
+
+//------------------------------------------------------------------------------
+//                             Class Declaration
+//------------------------------------------------------------------------------
 //! Normal reply.
 class StreamHttpReply: public AbstractStreamHttpReply
 {

--- a/src/internals/StreamHttpRequest.hpp
+++ b/src/internals/StreamHttpRequest.hpp
@@ -65,8 +65,8 @@ public:
     const ErrorString getError() const;
     Stream& getStream() { return m_stream; };
 
-   // Check if authenticated request
-   bool authenticate(const char * username, const char * password) const;
+    // Check if authenticated request
+    bool authenticate(const char * username, const char * password) const;
 
 private:
 
@@ -392,7 +392,6 @@ bool ArduinoHttpServer::StreamHttpRequest<MAX_BODY_SIZE>::authenticate(const cha
       DEBUG_ARDUINO_HTTP_SERVER_PRINTLN("Unsupported auth header");
       return false;
    }
-   String authData = m_authorizationField.getValueAsString().substring(6);
 
    String combinedInput;
    if (!combinedInput.reserve(strlen(username) + strlen(password) + 2))
@@ -407,8 +406,8 @@ bool ArduinoHttpServer::StreamHttpRequest<MAX_BODY_SIZE>::authenticate(const cha
    int encodedLength = Base64.encodedLength(combinedInput.length());
    char encodedString[encodedLength];
    Base64.encode(encodedString, combinedInput.c_str(), combinedInput.length());
-
-   if (authData == encodedString)
+   
+   if (strcmp(authData.c_str()+6,encodedString) == 0)
    {
       return true;
    }

--- a/src/internals/StreamHttpRequest.hpp
+++ b/src/internals/StreamHttpRequest.hpp
@@ -17,7 +17,7 @@
 #include "ArduinoHttpServerDebug.h"
 
 #include <Arduino.h>
-#include <base64.h>
+#include <Base64.h>
 
 #include <string.h>
 

--- a/src/internals/StreamHttpRequest.hpp
+++ b/src/internals/StreamHttpRequest.hpp
@@ -17,6 +17,7 @@
 #include "ArduinoHttpServerDebug.h"
 
 #include <Arduino.h>
+#include <base64.h>
 
 #include <string.h>
 
@@ -64,6 +65,9 @@ public:
     const ErrorString getError() const;
     Stream& getStream() { return m_stream; };
 
+   // Check if authenticated request
+   bool authenticate(const char * username, const char * password) const;
+
 private:
 
    enum class Error: char {
@@ -100,6 +104,7 @@ private:
    ArduinoHttpServer::HttpVersion m_version;
    ArduinoHttpServer::HttpField m_contentTypeField;
    ArduinoHttpServer::HttpField m_contentLengthField;
+   ArduinoHttpServer::HttpField m_authorizationField;
 
    Error m_error;
    ErrorMessageString m_errorDetail;
@@ -321,6 +326,10 @@ void ArduinoHttpServer::StreamHttpRequest<MAX_BODY_SIZE>::parseField(char lineBu
    {
       m_contentLengthField = httpField;
    }
+   else if(httpField.getType() == ArduinoHttpServer::HttpField::Type::AUTHORIZATION)
+   {
+      m_authorizationField = httpField;
+   }
    else
    {
       // Ignore other fields for now.
@@ -370,6 +379,41 @@ const ArduinoHttpServer::ErrorString ArduinoHttpServer::StreamHttpRequest<MAX_BO
    return errorString;
 }
 
+template <size_t MAX_BODY_SIZE>
+bool ArduinoHttpServer::StreamHttpRequest<MAX_BODY_SIZE>::authenticate(const char * username, const char * password) const
+{
+   if (m_authorizationField.getType() == HttpField::Type::NOT_SUPPORTED)
+   {
+      return false;
+   }
 
+   if (!m_authorizationField.getValueAsString().startsWith("Basic"))
+   {
+      DEBUG_ARDUINO_HTTP_SERVER_PRINTLN("Unsupported auth header");
+      return false;
+   }
+   String authData = m_authorizationField.getValueAsString().substring(6);
+
+   String combinedInput;
+   if (!combinedInput.reserve(strlen(username) + strlen(password) + 2))
+   {
+      DEBUG_ARDUINO_HTTP_SERVER_PRINTLN("Not enough memory");
+      return false;
+   }
+   combinedInput += username;
+   combinedInput += AHS_F(":");
+   combinedInput += password;
+
+   int encodedLength = Base64.encodedLength(combinedInput.length());
+   char encodedString[encodedLength];
+   Base64.encode(encodedString, combinedInput.c_str(), combinedInput.length());
+
+   if (authData == encodedString)
+   {
+      return true;
+   }
+
+   return false;
+}
 
 #endif // __ArduinoHttpServer__StreamHttpRequest__

--- a/src/internals/StreamHttpRequest.hpp
+++ b/src/internals/StreamHttpRequest.hpp
@@ -407,7 +407,7 @@ bool ArduinoHttpServer::StreamHttpRequest<MAX_BODY_SIZE>::authenticate(const cha
    char encodedString[encodedLength];
    Base64.encode(encodedString, combinedInput.c_str(), combinedInput.length());
    
-   if (strcmp(authData.c_str()+6,encodedString) == 0)
+   if (strcmp(m_authorizationField.getValueAsString().c_str()+6,encodedString) == 0)
    {
       return true;
    }


### PR DESCRIPTION
Hi QuickSander,

I really like this HTTP server, noticeably light. I was missing the basic authorization support so decided to add it.
There is only one caveat with this change, it does require dependency on another library to get base64 encoding which is needed for this task. I'm not sure I know how to mark that dependency so the Arduino IDE will be aware of that. That library is tiny so I hope it will be ok with you.

I also did some minor fix in your sample as it seems you are missing closing the connection.

If you are fine with that direction, I can add new sample to show the usage.

Thanks,
Tomer.