### PR TITLE
Feature/add headers

### DIFF
--- a/src/internals/StreamHttpReply.cpp
+++ b/src/internals/StreamHttpReply.cpp
@@ -19,7 +19,12 @@ ArduinoHttpServer::AbstractStreamHttpReply::AbstractStreamHttpReply(Stream& stre
 }
 
 void ArduinoHttpServer::AbstractStreamHttpReply::addHeader(const String& name, const String &value) {
-   
+   if (m_headerCount == MAX_HEADERS) return;
+
+   m_headerNames[m_headerCount] = name;
+   m_headerValues[m_headerCount] = value;
+
+   m_headerCount++;
 }
 
 //------------------------------------------------------------------------------

--- a/src/internals/StreamHttpReply.cpp
+++ b/src/internals/StreamHttpReply.cpp
@@ -18,6 +18,10 @@ ArduinoHttpServer::AbstractStreamHttpReply::AbstractStreamHttpReply(Stream& stre
 
 }
 
+void ArduinoHttpServer::AbstractStreamHttpReply::addHeader(const String& name, const String &value) {
+   
+}
+
 //------------------------------------------------------------------------------
 //! \brief Send this reply / print this reply to stream.
 //! \todo: Accept char* also for data coming directly from flash.
@@ -39,7 +43,6 @@ void ArduinoHttpServer::AbstractStreamHttpReply::send(const String& data, const 
 
    DEBUG_ARDUINO_HTTP_SERVER_PRINTLN("done.");
 }
-
 
 Stream& ArduinoHttpServer::AbstractStreamHttpReply::getStream()
 {

--- a/src/internals/StreamHttpReply.cpp
+++ b/src/internals/StreamHttpReply.cpp
@@ -43,6 +43,10 @@ void ArduinoHttpServer::AbstractStreamHttpReply::send(const String& data, const 
    getStream().print( AHS_F("Connection: close\r\n") );
    getStream().print( AHS_F("Content-Length: ") ); getStream().print( data.length()); getStream().print( AHS_F("\r\n") );
    getStream().print( AHS_F("Content-Type: ") ); getStream().print( m_contentType ); getStream().print( AHS_F("\r\n") );
+   for(int i = 0; i < m_headerCount; i++) {
+      getStream().print( m_headerNames[i] ); getStream().print(": "); getStream().print( m_headerValues[i] ); getStream().print( AHS_F("\r\n") );
+   }
+
    getStream().print( AHS_F("\r\n") );
    getStream().print( data ); getStream().print( AHS_F("\r\n") );
 

--- a/src/internals/StreamHttpReply.hpp
+++ b/src/internals/StreamHttpReply.hpp
@@ -25,6 +25,7 @@ class AbstractStreamHttpReply
 {
 
 public:
+    void addHeader(const String& name, const String &value);
     virtual void send(const String& data, const String& title);
 
 protected:

--- a/src/internals/StreamHttpReply.hpp
+++ b/src/internals/StreamHttpReply.hpp
@@ -11,8 +11,9 @@
 #define __ArduinoHttpServer__StreamHttpReply__
 
 #include <Arduino.h>
-
 #include "ArduinoHttpServerDebug.h"
+
+#define MAX_HEADERS  3
 
 namespace ArduinoHttpServer
 {
@@ -38,7 +39,9 @@ protected:
    constexpr static const char* CONTENT_TYPE_APPLICATION_JSON PROGMEM = "application/json";
 
 private:
-
+    String m_headerNames[MAX_HEADERS];
+    String m_headerValues[MAX_HEADERS];
+    int m_headerCount = 0;
    Stream& m_stream;
    String m_contentType; //!< Needs to be overridden to default when required. Therefore not const.
    const String m_code;


### PR DESCRIPTION
This adds the possibility to add maximum 3 extra header fields to the response. This is useful when using the ArduinoHttpServer to serve REST calls and you want the caller to reside somewhere else (like a local HTML file).

Usage: 

`httpReply.addHeader("Access-Control-Allow-Origin", "*");`

Tested and works on the Arduino MKR Wifi