### PR TITLE
Feature/add options method

### DIFF
--- a/src/internals/ArduinoHttpServerDebug.h
+++ b/src/internals/ArduinoHttpServerDebug.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2016 Sander van Woensel. All rights reserved.
 //
 //! Debug support
-
 #ifdef ARDUINO_HTTP_SERVER_DEBUG
    #define DEBUG_ARDUINO_HTTP_SERVER_PRINT(...) Serial.print(__VA_ARGS__)
    #define DEBUG_ARDUINO_HTTP_SERVER_PRINTLN(...) Serial.println(__VA_ARGS__)

--- a/src/internals/StreamHttpReply.cpp
+++ b/src/internals/StreamHttpReply.cpp
@@ -19,7 +19,12 @@ ArduinoHttpServer::AbstractStreamHttpReply::AbstractStreamHttpReply(Stream& stre
 }
 
 void ArduinoHttpServer::AbstractStreamHttpReply::addHeader(const String& name, const String &value) {
-   
+   if (m_headerCount == MAX_HEADERS) return;
+
+   m_headerNames[m_headerCount] = name;
+   m_headerValues[m_headerCount] = value;
+
+   m_headerCount++;
 }
 
 //------------------------------------------------------------------------------

--- a/src/internals/StreamHttpReply.cpp
+++ b/src/internals/StreamHttpReply.cpp
@@ -18,6 +18,10 @@ ArduinoHttpServer::AbstractStreamHttpReply::AbstractStreamHttpReply(Stream& stre
 
 }
 
+void ArduinoHttpServer::AbstractStreamHttpReply::addHeader(const String& name, const String &value) {
+   
+}
+
 //------------------------------------------------------------------------------
 //! \brief Send this reply / print this reply to stream.
 //! \todo: Accept char* also for data coming directly from flash.
@@ -39,7 +43,6 @@ void ArduinoHttpServer::AbstractStreamHttpReply::send(const String& data, const 
 
    DEBUG_ARDUINO_HTTP_SERVER_PRINTLN("done.");
 }
-
 
 Stream& ArduinoHttpServer::AbstractStreamHttpReply::getStream()
 {

--- a/src/internals/StreamHttpReply.cpp
+++ b/src/internals/StreamHttpReply.cpp
@@ -43,6 +43,10 @@ void ArduinoHttpServer::AbstractStreamHttpReply::send(const String& data, const 
    getStream().print( AHS_F("Connection: close\r\n") );
    getStream().print( AHS_F("Content-Length: ") ); getStream().print( data.length()); getStream().print( AHS_F("\r\n") );
    getStream().print( AHS_F("Content-Type: ") ); getStream().print( m_contentType ); getStream().print( AHS_F("\r\n") );
+   for(int i = 0; i < m_headerCount; i++) {
+      getStream().print( m_headerNames[i] ); getStream().print(": "); getStream().print( m_headerValues[i] ); getStream().print( AHS_F("\r\n") );
+   }
+
    getStream().print( AHS_F("\r\n") );
    getStream().print( data ); getStream().print( AHS_F("\r\n") );
 

--- a/src/internals/StreamHttpReply.hpp
+++ b/src/internals/StreamHttpReply.hpp
@@ -25,6 +25,7 @@ class AbstractStreamHttpReply
 {
 
 public:
+    void addHeader(const String& name, const String &value);
     virtual void send(const String& data, const String& title);
 
 protected:

--- a/src/internals/StreamHttpReply.hpp
+++ b/src/internals/StreamHttpReply.hpp
@@ -11,8 +11,9 @@
 #define __ArduinoHttpServer__StreamHttpReply__
 
 #include <Arduino.h>
-
 #include "ArduinoHttpServerDebug.h"
+
+#define MAX_HEADERS  3
 
 namespace ArduinoHttpServer
 {
@@ -38,7 +39,9 @@ protected:
    constexpr static const char* CONTENT_TYPE_APPLICATION_JSON PROGMEM = "application/json";
 
 private:
-
+    String m_headerNames[MAX_HEADERS];
+    String m_headerValues[MAX_HEADERS];
+    int m_headerCount = 0;
    Stream& m_stream;
    String m_contentType; //!< Needs to be overridden to default when required. Therefore not const.
    const String m_code;

--- a/src/internals/StreamHttpRequest.hpp
+++ b/src/internals/StreamHttpRequest.hpp
@@ -28,7 +28,7 @@ namespace ArduinoHttpServer
 
 enum class Method : char
 {
-   Invalid, Get, Put, Post, Head, Delete
+   Invalid, Get, Put, Post, Head, Delete, Options
 };
 
 
@@ -240,8 +240,8 @@ void ArduinoHttpServer::StreamHttpRequest<MAX_BODY_SIZE>::parseMethod(char lineB
    if(m_error!=Error::OK) { return; }
 
    // First strtok call, initialize with cached line buffer.
-   // len("DELETE") + 1 for terminating null = 7
-   FixString<7U> token(strtok_r(lineBuffer, " ", &m_lineBufferStrTokContext));
+   // len("OPTIONS") + 1 for terminating null = 7
+   FixString<8U> token(strtok_r(lineBuffer, " ", &m_lineBufferStrTokContext));
 
    if(token == "GET")
    {
@@ -262,6 +262,10 @@ void ArduinoHttpServer::StreamHttpRequest<MAX_BODY_SIZE>::parseMethod(char lineB
    else if (token == "DELETE")
    {
       m_method = Method::Delete;
+   }
+   else if (token == "OPTIONS") 
+   {
+      m_method = Method::Options;
    }
    else
    {
@@ -290,7 +294,6 @@ void ArduinoHttpServer::StreamHttpRequest<MAX_BODY_SIZE>::parseVersion()
     else
     {
         setError(Error::PARSE_ERROR_INVALID_HTTP_VERSION, version);
-
     }
 
 }
@@ -319,7 +322,7 @@ template <size_t MAX_BODY_SIZE>
 void ArduinoHttpServer::StreamHttpRequest<MAX_BODY_SIZE>::parseField(char lineBuffer[])
 {
    if(m_error!=Error::OK) { return; }
-
+   
    ArduinoHttpServer::HttpField httpField(lineBuffer);
 
    if(httpField.getType() == ArduinoHttpServer::HttpField::Type::CONTENT_TYPE)


### PR DESCRIPTION
Implement `OPTIONS` method. 

When using REST calls using a browser, the `OPTIONS` call is made as preflight, before any other calls are done. 